### PR TITLE
fix zero padding

### DIFF
--- a/utils/cryptography.go
+++ b/utils/cryptography.go
@@ -61,7 +61,8 @@ func DecryptValidatorKeyInfo(file *schemas.IPFSResponseType, keypairForIndex sch
 
 	// zero padded secret
 	nodeOperatorSecret := make([]byte, 32)
-	copy(nodeOperatorSecret, nodeOperatorSharedSecret.Bytes())
+	secretLen := len(nodeOperatorSharedSecret.Bytes())
+	copy(nodeOperatorSecret[32-secretLen:], nodeOperatorSharedSecret.Bytes())
 
 	// For compatibility, if all three encrypted fields are in the form [iv]:[data], we decrypt them using CBC mode
 	isUsingCBC := false


### PR DESCRIPTION
Hi. 

I've got an error when I test some cases using the latest branch. 

And I found an error related to zero-padding.

error : 
- panic: cipher: message authentication failed

one of my cases : 
```
Processing stake request for validator: 0xa6 and phase: LIVE and BNFT Holder: 0x------- and ipfs path: ------
panic: cipher: message authentication failed

goroutine 1 [running]:
github.com/GadzeFinance/etherfi-sync-clientv2/utils.DecryptGCM({0x140000b0580?, 0x94?}, {0x1400008e780, 0x20, 0x20})
	.../github/etherfi-sync-clientv2/utils/cryptography.go:133 +0x19c
github.com/GadzeFinance/etherfi-sync-clientv2/utils.DecryptValidatorKeyInfo(0x14000010c58?, {{0x1400006ebd0?, 0x1400071c000?}, {0x14000018a00?, 0x1?}})
	.../github/etherfi-sync-clientv2/utils/cryptography.go:94 +0x3e4
```

This is caused by https://github.com/GadzeFinance/etherfi-sync-clientv2/blob/5fa42010834b72e5bf36c3fc9a2358f25fa23f05/utils/cryptography.go#L63-L64

It will pad zero like the following : 

CB2BB1F0FED08EE04D621B068322259BA988D6F948A5471B5DDC0D601B02C1`00`


But the correct one is the following :

`00`CB2BB1F0FED08EE04D621B068322259BA988D6F948A5471B5DDC0D601B02C1

