### PR TITLE
fetch all keys by iterating all bids

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,0 @@
-{
-	"GRAPH_URL": "https://api.studio.thegraph.com/query/41778/etherfi-dev-goerli-3/version/latest",
-	"BIDDER": "0xD0d7F8a5a86d8271ff87ff24145Cf40CEa9F7A39",
-	"PRIVATE_KEYS_FILE_LOCATION": "./NO-admind0d/privateEtherfiKeystore-1699550135084.json",
-	"OUTPUT_LOCATION": "output",
-	"PASSWORD": "Password123!",
-	"IPFS_GATEWAY": "https://etherfi-goerli.infura-ipfs.io/ipfs"
-}

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func fetchValidatorKeys(config schemas.Config, db *sql.DB) error {
 	// TODO
 	// there is no way of sorting against latest won bids. beacuse sync-client did not store keys which is not status:won in data.db.
 	// at the moment, iterating all keys is the clear way to get recent won bids.
-	pubkeyIndex = 0
+	pubkeyIndex = -1
 
 	for {
 		fmt.Printf("Begin pubkeyIndex : %d\n", pubkeyIndex)

--- a/utils/database.go
+++ b/utils/database.go
@@ -12,12 +12,29 @@ func GetIDCount(db *sql.DB, bidID string) (int, error) {
 
 	return count, err
 }
+func GetLastPubkeyIndex(db *sql.DB) (int64, error) {
+
+	query := "SELECT pubkeyIndex FROM winning_bids order by pubkeyIndex desc"
+	var pubkeyIndex int64
+	err := db.QueryRow(query).Scan(&pubkeyIndex)
+	switch {
+	case err == sql.ErrNoRows:
+		return -1, nil
+	case err != nil:
+		return -1, err
+	default:
+	}
+
+	return pubkeyIndex, nil
+	// return strconv.ParseInt(pubkeyIndex, 10, 64)
+}
 
 func CreateTable(db *sql.DB) error {
 	// Create the table if it doesn't exist
 	createTableQuery := `
 	CREATE TABLE IF NOT EXISTS winning_bids (
 		id STRING PRIMARY KEY,
+		pubkeyIndex INTEGER,
 		pubkey TEXT,
 		password TEXT,
 		nodeAddress TEXT,

--- a/utils/file.go
+++ b/utils/file.go
@@ -42,7 +42,7 @@ func FetchFromIPFS(gatewayURL string, cid string) (*schemas.IPFSResponseType, er
 	return &ipfsResponse, nil
 }
 
-func SaveKeysToFS(output_location string, validatorInfo schemas.ValidatorKeyInfo, bidId string, validatorPublicKey string, nodeAddress string, db *sql.DB) error {
+func SaveKeysToFS(output_location string, validatorInfo schemas.ValidatorKeyInfo, bidId string, pubkeyIndex int64, validatorPublicKey string, nodeAddress string, db *sql.DB) error {
 
 	// Step 1: Create directory and add data to the directory
 	if err := createDir(output_location); err != nil {
@@ -86,14 +86,14 @@ func SaveKeysToFS(output_location string, validatorInfo schemas.ValidatorKeyInfo
 		return fmt.Errorf("creating node_address.txt: %w", err)
 	}
 
-	query := "REPLACE INTO winning_bids (id, pubkey, password, nodeAddress, keystore) VALUES (?, ?, ?, ?, ?)"
+	query := "REPLACE INTO winning_bids (id, pubkeyIndex, pubkey, password, nodeAddress, keystore) VALUES (?, ?, ?, ?, ?, ?)"
 	stmt, err := db.Prepare(query)
 	if err != nil {
 		log.Fatalf("creating bid update query: %v", err)
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(bidId, validatorPublicKey, string(validatorInfo.ValidatorKeyPassword), nodeAddress, string(validatorInfo.ValidatorKeyFile))
+	_, err = stmt.Exec(bidId, pubkeyIndex, validatorPublicKey, string(validatorInfo.ValidatorKeyPassword), nodeAddress, string(validatorInfo.ValidatorKeyFile))
 	if err != nil {
 		log.Fatalf("storing bids in DB: %v", err)
 	}


### PR DESCRIPTION
### Issue

At the moment, sync-client does not allow iterating all bids. 
It is restricted by hardcoded values. (`Found  1000  stake requests.`)
If we exceed 1000 keys, it will result in fetching fewer keys than won bids.


### Changes

- Added pubkeyIndex field in data.db
- Fetching keys by 500 (hardcoded)
- Print total skipped counts on each batch instead of printing skipped bids.
```
Begin pubkeyIndex : 0
Found  500  stake requests.
Skipping 500 stake requests because these have already been processed.
Begin pubkeyIndex : 500
Found  500  stake requests.
Skipping 500 stake requests because these have already been processed.
complete: fetched all keys
```

### Requires

- Wipe the current data.db and run from scratch. (not compatible)


### Improvements worth considering

- Make dir for keys and passwords regardless of the name of output_dir. At the moment it works only named by `output`.
- Concurrent fetching multiple keys considering rate-limit of ipfs and graphql.
- Metrics based on bids status