### PR TITLE
Updated Config file and added single retry on ipfs fetch

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,11 +1,9 @@
 {
-  "GRAPH_URL": "https://api.studio.thegraph.com/query/41778/etherfi-phase2-mainnet/version/latest",
-  "IPFS_GATEWAY": "https://ether-fi-mainnet.infura-ipfs.io/ipfs",
-  "BIDDER": "",
-  "PRIVATE_KEYS_FILE_LOCATION": "",
-  "OUTPUT_LOCATION": "./output",
-  "PASSWORD": "",
-  "CONSENSUS_FOLDER_LOCATION": ".",
-  "ETHERFI_SC_CLIENT_LOCATION": ".",
-  "PATH_TO_PRYSYM_SH": "."
+	"GRAPH_URL": "https://gateway-arbitrum.network.thegraph.com/api/73b09012e7e6301b5e0e20b45fd66b48/deployments/id/QmYXL6XeXyGC2DCnoQ45ApG68pi8irCZdRdtFx69FetRDd",
+	"IPFS_GATEWAY": "https://ether-fi-mainnet.infura-ipfs.io/ipfs",
+	"BIDDER": "",
+	"OUTPUT_LOCATION": "./output",
+	"PRIVATE_KEYS_FILE_LOCATION": ".",
+	"PASSWORD": ".",
+	"USE_LAST_VALIDATOR_INDEX": false
 }

--- a/main.go
+++ b/main.go
@@ -48,7 +48,6 @@ func run() error {
 }
 
 func fetchValidatorKeys(config schemas.Config, db *sql.DB) error {
-
 	fmt.Println("Fetching Validator Keys from IPFS...")
 	privateKey, err := utils.ParseKeystoreFile(config.PRIVATE_KEYS_FILE_LOCATION)
 	if err != nil {
@@ -68,7 +67,9 @@ func fetchValidatorKeys(config schemas.Config, db *sql.DB) error {
 	// TODO
 	// there is no way of sorting against latest won bids. beacuse sync-client did not store keys which is not status:won in data.db.
 	// at the moment, iterating all keys is the clear way to get recent won bids.
-	pubkeyIndex = -1
+	if (config.USE_LAST_VALIDATOR_INDEX == true) {
+		pubkeyIndex = -1
+	}
 
 	for {
 		fmt.Printf("Begin pubkeyIndex : %d\n", pubkeyIndex)

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func fetchValidatorKeys(config schemas.Config, db *sql.DB) error {
 
 	for {
 		fmt.Printf("Begin pubkeyIndex : %d\n", pubkeyIndex)
+
 		bids, err := retrieveBidsFromSubgraph(config.GRAPH_URL, config.BIDDER, pubkeyIndex)
 		if err != nil {
 			return fmt.Errorf("retrieveBidsFromSubgraph: %w", err)
@@ -113,17 +114,11 @@ func fetchValidatorKeys(config schemas.Config, db *sql.DB) error {
 			validator := bid.Validator
 			ipfsHashForEncryptedValidatorKey := validator.IpfsHashForEncryptedValidatorKey
 
-			retry := false
 			IPFSResponse, err := utils.FetchFromIPFS(config.IPFS_GATEWAY, ipfsHashForEncryptedValidatorKey)
 			if err != nil {
-				if (!retry) {
-					fmt.Printf("Fetch timed out, Retrying Once: " + ipfsHashForEncryptedValidatorKey)
-					retry = true
-					IPFSResponse, err = utils.FetchFromIPFS(config.IPFS_GATEWAY, ipfsHashForEncryptedValidatorKey)
-					if err != nil {
-						return fmt.Errorf("FetchFromIPFS: %w", err)
-					}
-				} else {
+				fmt.Println("Fetch timed out, Retrying Once: " + ipfsHashForEncryptedValidatorKey)
+				IPFSResponse, err = utils.FetchFromIPFS(config.IPFS_GATEWAY, ipfsHashForEncryptedValidatorKey)
+				if err != nil {
 					return fmt.Errorf("FetchFromIPFS: %w", err)
 				}
 			}
@@ -152,7 +147,6 @@ func fetchValidatorKeys(config schemas.Config, db *sql.DB) error {
 			}
 		}
 		fmt.Printf("Skipping %d stake requests because these have already been processed.\n", skipCount)
-
 	}
 }
 

--- a/schemas/schemas.go
+++ b/schemas/schemas.go
@@ -7,6 +7,7 @@ type Config struct {
 	OUTPUT_LOCATION            string `json:"OUTPUT_LOCATION"`
 	PASSWORD                   string `json:"PASSWORD"`
 	IPFS_GATEWAY               string `json:"IPFS_GATEWAY"`
+	USE_LAST_VALIDATOR_INDEX   bool `json:"USE_LAST_VALIDATOR_INDEX"`
 }
 
 type ValidatorKeyInfo struct {

--- a/utils/file.go
+++ b/utils/file.go
@@ -22,7 +22,7 @@ func FetchFromIPFS(gatewayURL string, cid string) (*schemas.IPFSResponseType, er
 		return nil, fmt.Errorf("creating IPFS request: %w", err)
 	}
 	request.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: time.Second * 30}
+	client := &http.Client{Timeout: time.Second * 10}
 	response, err := client.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from IPFS: %w", err)


### PR DESCRIPTION
Added a single retry on failed IPFS fetch as this usually allows for continued download instead of the client failing.

Added the option in the config file to let the client fetch only new bids (depending on the local database) instead of running on all bids every time

setting USE_LAST_VALIDATOR_INDEX to false in the config will use the last recorded index in the graph query.